### PR TITLE
Add option to customize creating sockets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,7 @@
             "--colors",
             "${file}"
         ],
+        "env": {"DEBUG": "proxy*"},
         "console": "integratedTerminal",
         "internalConsoleOptions": "neverOpen"
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+    "editor.formatOnSave": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,11 @@
         "nyc": "15.1.0",
         "parse-cache-control": "1.0.1",
         "pem": "1.14.6",
+        "proxy": "^1.0.2",
         "semantic-release": "19.0.3",
         "sinon": "14.0.0",
-        "stream-buffers": "3.0.2"
+        "stream-buffers": "3.0.2",
+        "tunnel": "^0.0.6"
       },
       "engines": {
         "node": ">=12.0"
@@ -1287,6 +1289,101 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/args/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/args/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/args/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/args/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/args/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -1385,6 +1482,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/basic-auth-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/basic-auth-parser/-/basic-auth-parser-0.0.2.tgz",
+      "integrity": "sha512-Y7OBvWn+JnW45JWHLY6ybYub2k9cXCMrtCyO1Hds2s6eqClqWhPnOQpgXUPjAiMHj+A8TEPIQQ1dYENnJoBOHQ==",
       "dev": true
     },
     "node_modules/before-after-hook": {
@@ -4047,6 +4150,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4943,6 +5055,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -8344,6 +8465,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proxy/-/proxy-1.0.2.tgz",
+      "integrity": "sha512-KNac2ueWRpjbUh77OAFPZuNdfEqNynm9DD4xHT14CccGpW8wKZwEkN0yjlb7X9G9Z9F55N0Q+1z+WfgAhwYdzQ==",
+      "dev": true,
+      "dependencies": {
+        "args": "5.0.1",
+        "basic-auth-parser": "0.0.2",
+        "debug": "^4.1.1"
+      },
+      "bin": {
+        "proxy": "bin/proxy.js"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -9608,6 +9743,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -11039,6 +11183,82 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -11110,6 +11330,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "basic-auth-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/basic-auth-parser/-/basic-auth-parser-0.0.2.tgz",
+      "integrity": "sha512-Y7OBvWn+JnW45JWHLY6ybYub2k9cXCMrtCyO1Hds2s6eqClqWhPnOQpgXUPjAiMHj+A8TEPIQQ1dYENnJoBOHQ==",
       "dev": true
     },
     "before-after-hook": {
@@ -13093,6 +13319,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -13738,6 +13970,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
       "dev": true
     },
     "ms": {
@@ -16157,6 +16395,17 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
+    "proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proxy/-/proxy-1.0.2.tgz",
+      "integrity": "sha512-KNac2ueWRpjbUh77OAFPZuNdfEqNynm9DD4xHT14CccGpW8wKZwEkN0yjlb7X9G9Z9F55N0Q+1z+WfgAhwYdzQ==",
+      "dev": true,
+      "requires": {
+        "args": "5.0.1",
+        "basic-auth-parser": "0.0.2",
+        "debug": "^4.1.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -17117,6 +17366,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -72,9 +72,11 @@
     "nyc": "15.1.0",
     "parse-cache-control": "1.0.1",
     "pem": "1.14.6",
+    "proxy": "^1.0.2",
     "semantic-release": "19.0.3",
     "sinon": "14.0.0",
-    "stream-buffers": "3.0.2"
+    "stream-buffers": "3.0.2",
+    "tunnel": "^0.0.6"
   },
   "lint-staged": {
     "*.js": "eslint"

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -175,6 +175,12 @@ export interface Http2Options {
   rejectUnauthorized?: boolean;
 }
 
+export interface CreatSocketOptions {
+  alpnProtocol: ALPNProtocol;
+  //TODO: real types for this
+  createSocket: (requestOptions: any) => any;
+}
+
 export interface ContextOptions {
   /**
    * Value of `user-agent` request header
@@ -210,6 +216,8 @@ export interface ContextOptions {
 
   h1?: Http1Options;
   h2?: Http2Options;
+
+  socketFactory?: CreatSocketOptions;
 }
 
 export class AbortSignal {

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -175,12 +175,6 @@ export interface Http2Options {
   rejectUnauthorized?: boolean;
 }
 
-export interface CreatSocketOptions {
-  alpnProtocol: ALPNProtocol;
-  //TODO: real types for this
-  createSocket: (requestOptions: any) => any;
-}
-
 export interface ContextOptions {
   /**
    * Value of `user-agent` request header
@@ -217,7 +211,7 @@ export interface ContextOptions {
   h1?: Http1Options;
   h2?: Http2Options;
 
-  socketFactory?: CreatSocketOptions;
+  socketFactory?: (requestOptions: any) => any;
 }
 
 export class AbortSignal {

--- a/test/core/proxy.test.js
+++ b/test/core/proxy.test.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const tunnel = require('tunnel');
+const Proxy = require('proxy');
+const { context, ALPN_HTTP1_1, ALPN_HTTP2 } = require('../../src/core');
+
+// This should go into our code base
+const createSocketFactory = (port) => {
+  // Always use `httpOverHttp` - secure handshake is handled in the `helix-fetch` request layer.
+  // This is for HTTP proxy support, we still need to figure out how to support HTTPs proxy.
+  const tunnelingAgent = tunnel.httpOverHttp({
+    proxy: {
+      host: 'localhost',
+      port,
+    },
+  });
+  // Promisify the `createSocket` method of the `tunnelingAgent`
+  const createSocket = (requestOptions) => new Promise((resolve) => {
+    tunnelingAgent.createSocket(requestOptions, (socket) => {
+      resolve(socket);
+    });
+  });
+  return createSocket;
+};
+
+describe('Proxy tests', () => {
+  let proxy;
+  let proxyPort;
+
+  before((done) => {
+    proxy = Proxy();
+    proxy.listen(() => {
+      proxyPort = proxy.address().port;
+      done();
+    });
+  });
+
+  after((done) => {
+    proxy.once('close', () => {
+      done();
+    });
+    proxy.close();
+  });
+
+  it('Tunnel to HTTP 1.1 server using HTTP over HTTP proxy', async () => {
+    const customCtx = context({
+      socketFactory: {
+        alpnProtocol: ALPN_HTTP1_1,
+        createSocket: createSocketFactory(proxyPort),
+      },
+    });
+    try {
+      const resp = await customCtx.request('http://httpbin.org/status/200');
+      assert.strictEqual(resp.statusCode, 200);
+      assert.strictEqual(resp.httpVersionMajor, 1);
+    } finally {
+      await customCtx.reset();
+    }
+  });
+
+  it('Tunnel to HTTP 1.1 server with HTTPS over HTTP proxy', async () => {
+    const customCtx = context({
+      socketFactory: {
+        alpnProtocol: ALPN_HTTP1_1,
+        createSocket: createSocketFactory(proxyPort),
+      },
+    });
+    try {
+      const resp = await customCtx.request('https://httpbin.org/status/200');
+      assert.strictEqual(resp.statusCode, 200);
+      assert.strictEqual(resp.httpVersionMajor, 1);
+    } finally {
+      await customCtx.reset();
+    }
+  });
+
+  it('Tunnel to HTTP2 server using HTTPS over HTTP proxy', async () => {
+    const customCtx = context({
+      socketFactory: {
+        alpnProtocol: ALPN_HTTP2,
+        createSocket: createSocketFactory(proxyPort),
+      },
+    });
+    try {
+      const resp = await customCtx.request('https://www.nghttp2.org/httpbin/status/200');
+      assert.strictEqual(resp.statusCode, 200);
+      assert.strictEqual(resp.httpVersionMajor, 2);
+    } finally {
+      await customCtx.reset();
+    }
+  });
+
+  it.skip('Normal HTTP 2 request to check Im not going crazy', async () => {
+    const customCtx = context();
+    try {
+      const resp = await customCtx.request('https://www.nghttp2.org/httpbin/status/200');
+      assert.strictEqual(resp.statusCode, 200);
+      assert.strictEqual(resp.httpVersionMajor, 2);
+    } finally {
+      await customCtx.reset();
+    }
+  });
+});

--- a/test/core/proxy.test.js
+++ b/test/core/proxy.test.js
@@ -15,7 +15,7 @@
 const assert = require('assert');
 const tunnel = require('tunnel');
 const Proxy = require('proxy');
-const { context, ALPN_HTTP1_1, ALPN_HTTP2 } = require('../../src/core');
+const { context, ALPN_HTTP1_1 } = require('../../src/core');
 
 // This should go into our code base
 const createSocketFactory = (port) => {
@@ -57,10 +57,7 @@ describe('Proxy tests', () => {
 
   it('Tunnel to HTTP 1.1 server using HTTP over HTTP proxy', async () => {
     const customCtx = context({
-      socketFactory: {
-        alpnProtocol: ALPN_HTTP1_1,
-        createSocket: createSocketFactory(proxyPort),
-      },
+      socketFactory: createSocketFactory(proxyPort),
     });
     try {
       const resp = await customCtx.request('http://httpbin.org/status/200');
@@ -73,10 +70,9 @@ describe('Proxy tests', () => {
 
   it('Tunnel to HTTP 1.1 server with HTTPS over HTTP proxy', async () => {
     const customCtx = context({
-      socketFactory: {
-        alpnProtocol: ALPN_HTTP1_1,
-        createSocket: createSocketFactory(proxyPort),
-      },
+      // Make sure we don't upgrade to HTTP2
+      alpnProtocols: [ALPN_HTTP1_1],
+      socketFactory: createSocketFactory(proxyPort),
     });
     try {
       const resp = await customCtx.request('https://httpbin.org/status/200');
@@ -89,10 +85,7 @@ describe('Proxy tests', () => {
 
   it('Tunnel to HTTP2 server using HTTPS over HTTP proxy', async () => {
     const customCtx = context({
-      socketFactory: {
-        alpnProtocol: ALPN_HTTP2,
-        createSocket: createSocketFactory(proxyPort),
-      },
+      socketFactory: createSocketFactory(proxyPort),
     });
     try {
       const resp = await customCtx.request('https://www.nghttp2.org/httpbin/status/200');


### PR DESCRIPTION
So on the helix-fetch public API level - this PR adds the ability to provide a custom constructor for creating a network socket that will be used for performing a request.

Extension to the public API is pretty simple: consumer needs to provide a function creating a socket, ~and ALPNProtocol (HTTP 1 vs HTTP 2) that should be used for the request (because we override socket creation, we can't depend on the ALPN negotiation that's originally in `helix-fetch` request layer)~

The last part of the PR is the `proxy.test.js` file which shows how to use the new API to provide proxy support by using npm's `tunnel` package. 